### PR TITLE
Reconfigure initialization (a bit) and create gulp module builder.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,12 @@
 /dist
 /node_modules
 /src/components
+
+# Ignore all the modules
+/src/modules
+
+# Except for the example ones
+!/src/modules/core
+!/src/modules/error
+!/src/modules/large
+!/src/modules/small

--- a/.gitignore
+++ b/.gitignore
@@ -5,12 +5,3 @@
 /dist
 /node_modules
 /src/components
-
-# Ignore all the modules
-/src/modules
-
-# Except for the example ones
-!/src/modules/core
-!/src/modules/error
-!/src/modules/large
-!/src/modules/small

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ npm run packageinstall
 
 `gulp build` compile to `dist`.
 
+`gulp module` creates a new module.
+
 ### Bower
 
 Bower is set up with Angular, standard Angular modules, Underscore, and Helios Frame Runner. Packages are installed to `src/components`.

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "gulp-autoprefixer": "^3.0.2",
     "gulp-concat": "^2.6.0",
     "gulp-cssmin": "^0.1.7",
+    "gulp-file": "^0.2.0",
     "gulp-imagemin": "^2.3.0",
     "gulp-inject": "^3.0.0",
     "gulp-jshint": "^1.11.2",
@@ -25,6 +26,9 @@
     "gulp-svgmin": "^1.2.0",
     "gulp-svgstore": "^5.0.5",
     "gulp-uglify": "^1.4.1",
+    "gulp-util": "^3.0.7",
+    "inquirer": "^0.11.0",
+    "path-exists": "^2.1.0",
     "run-sequence": "^1.1.4"
   },
   "dependencies": {},

--- a/src/index.html
+++ b/src/index.html
@@ -31,8 +31,8 @@
 
   <!-- inject:css -->
   <link rel="stylesheet" href="modules/core/css/core.css">
-  <link rel="stylesheet" href="modules/small/css/small.css">
   <link rel="stylesheet" href="modules/large/css/large.css">
+  <link rel="stylesheet" href="modules/small/css/small.css">
   <!-- endinject -->
 
   <!-- Favicons -->
@@ -66,14 +66,14 @@
   <script src="modules/core/init.js"></script>
   <script src="modules/large/init.js"></script>
   <script src="modules/test/init.js"></script>
-  <script src="modules/error/error.controller.js"></script>
   <script src="modules/core/app.ctrl.js"></script>
   <script src="modules/core/features.service.js"></script>
   <script src="modules/core/loader.service.js"></script>
   <script src="modules/core/resize.service.js"></script>
-  <script src="modules/small/small.directive.js"></script>
+  <script src="modules/error/error.controller.js"></script>
   <script src="modules/large/example.ctrl.js"></script>
   <script src="modules/large/large.directive.js"></script>
+  <script src="modules/small/small.directive.js"></script>
   <script src="modules/core/config/core.routes.js"></script>
   <script src="modules/core/config/core.statechangerror.js"></script>
   <script src="modules/core/values/constants.value.js"></script>

--- a/src/index.html
+++ b/src/index.html
@@ -31,8 +31,8 @@
 
   <!-- inject:css -->
   <link rel="stylesheet" href="modules/core/css/core.css">
-  <link rel="stylesheet" href="modules/large/css/large.css">
   <link rel="stylesheet" href="modules/small/css/small.css">
+  <link rel="stylesheet" href="modules/large/css/large.css">
   <!-- endinject -->
 
   <!-- Favicons -->
@@ -63,14 +63,17 @@
 
   <!-- inject:js -->
   <script src="modules/core/app.js"></script>
+  <script src="modules/core/init.js"></script>
+  <script src="modules/large/init.js"></script>
+  <script src="modules/test/init.js"></script>
+  <script src="modules/error/error.controller.js"></script>
   <script src="modules/core/app.ctrl.js"></script>
   <script src="modules/core/features.service.js"></script>
   <script src="modules/core/loader.service.js"></script>
   <script src="modules/core/resize.service.js"></script>
-  <script src="modules/error/error.controller.js"></script>
+  <script src="modules/small/small.directive.js"></script>
   <script src="modules/large/example.ctrl.js"></script>
   <script src="modules/large/large.directive.js"></script>
-  <script src="modules/small/small.directive.js"></script>
   <script src="modules/core/config/core.routes.js"></script>
   <script src="modules/core/config/core.statechangerror.js"></script>
   <script src="modules/core/values/constants.value.js"></script>

--- a/src/modules/core/app.js
+++ b/src/modules/core/app.js
@@ -1,16 +1,39 @@
-;(function () {
+/**
+ * The main starting script.
+ *
+ * A global function, 'AppConfig', is used to deal with any modules in the app.
+ * The main module is then registered with the vendor dependencies.
+ *
+ * Any module can easily be registered anywhere without having to come back here
+ * to declare it. Just call: AppConfig.registerModule('app.modulename', [any, dependencies]);
+ */
+
+
+// Init the application configuration module for AngularJS application
+var AppConfig = (function() {
   'use strict';
+  // Init module configuration options
+  var appModuleName = 'app';
+  var appModuleVendorDependencies = ['ngAnimate', 'ui.router'];
 
-  angular
-    .module('app', [
+  // Add a new module
+  var registerModule = function(moduleName, dependencies) {
+    // Create angular module
+    angular.module(moduleName, dependencies || []);
 
-      'ui.router',
-      'ngAnimate',
+    // Add the module to the AngularJS configuration file
+    angular.module(appModuleName).requires.push(moduleName);
+  };
 
-      'app.core',
-      'app.exampleModule',
+  return {
+    appModuleName: appModuleName,
+    appModuleVendorDependencies: appModuleVendorDependencies,
+    registerModule: registerModule
+  };
+})();
 
-      'heliosFrameRunner'
-    ]);
-
+(function() {
+  'use strict';
+  //Start by defining the main module and adding the module dependencies
+  angular.module(AppConfig.appModuleName, AppConfig.appModuleVendorDependencies);
 })();

--- a/src/modules/core/css/core.css
+++ b/src/modules/core/css/core.css
@@ -1,3 +1,8 @@
 html, body {
   height: 100%;
   width: 100%; }
+
+.no-animate, .no-animate.ng-animate {
+  -webkit-animation: none 0s !important;
+          animation: none 0s !important;
+  transition-duration: 0s !important; }

--- a/src/modules/core/init.js
+++ b/src/modules/core/init.js
@@ -1,0 +1,6 @@
+(function(AppConfig) {
+  'use strict';
+
+  AppConfig.registerModule('app.core');
+
+})(window.AppConfig);

--- a/src/modules/large/css/large.css
+++ b/src/modules/large/css/large.css
@@ -2,5 +2,10 @@ html, body {
   height: 100%;
   width: 100%; }
 
+.no-animate, .no-animate.ng-animate {
+  -webkit-animation: none 0s !important;
+          animation: none 0s !important;
+  transition-duration: 0s !important; }
+
 .example-module {
   display: block; }

--- a/src/modules/large/example.ctrl.js
+++ b/src/modules/large/example.ctrl.js
@@ -2,7 +2,7 @@
   'use strict';
 
   angular
-    .module('app.exampleModule', [])
+    .module('app.exampleModule')
     .controller('ExampleController', ExampleController);
 
   function ExampleController($scope, $q) {

--- a/src/modules/large/init.js
+++ b/src/modules/large/init.js
@@ -1,0 +1,6 @@
+(function(AppConfig) {
+  'use strict';
+
+  AppConfig.registerModule('app.exampleModule');
+
+})(window.AppConfig);

--- a/src/modules/small/css/small.css
+++ b/src/modules/small/css/small.css
@@ -2,6 +2,11 @@ html, body {
   height: 100%;
   width: 100%; }
 
+.no-animate, .no-animate.ng-animate {
+  -webkit-animation: none 0s !important;
+          animation: none 0s !important;
+  transition-duration: 0s !important; }
+
 .small {
   display: block;
   background: #ddd;


### PR DESCRIPTION
- Module registration is now handled by a global helper singleton.
- Gulp task to automate building modules.

Now if you want a new module just call `gulp module` and at the prompt, name it. A new directory and init script will be created and you're ready to go.

I noticed that Iain is using namespaced module names (eg. `app.example`). That's totally fine. Just enter that in the prompt and the directory will be called `example` but the registered module will still be `app.example`.
