### PR TITLE
Update include paths.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -98,7 +98,11 @@ gulp.task('sass', function() {
     .pipe(plugins.sourcemaps.init())
       .pipe(plugins.sass({
         style: 'compressed',
-        indentedSyntax: true
+        indentedSyntax: true,
+        includePaths: [
+          './src/components/standardize',
+          src.modules + '/core/sass'
+        ]
       }))
       .on('error', swallowError)
       .pipe(plugins.autoprefixer('last 2 version', 'safari 5', 'ie 8', 'ie 9', 'opera 12.1', 'ios 6', 'android 4'))

--- a/src/modules/core/sass/core.sass
+++ b/src/modules/core/sass/core.sass
@@ -1,2 +1,4 @@
+@import standardize.sass
+
 @import global/variables
 @import global/functions

--- a/src/modules/large/sass/large.sass
+++ b/src/modules/large/sass/large.sass
@@ -1,2 +1,4 @@
-@import ../../core/sass/core
+@import global/variables
+@import global/functions
+
 @import components/example-component

--- a/src/modules/small/small.sass
+++ b/src/modules/small/small.sass
@@ -1,4 +1,4 @@
-@import ../core/sass/core
+@import global/variables
 
 .small
   display: block


### PR DESCRIPTION
I updated the `sass` compiler with a couple of include paths. This helps us out so that we don't have to use `../`.

Path one goes to the standardize directory in components so that we just include it at the top of core.sass with `@import standardize.sass`.

The second one includes `src/core` so if you want to include the variables file in another module you just put `@import global/variables` at the top of the file.
